### PR TITLE
Fix truncation of big files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,15 @@ Install [nodejs](https://nodejs.org/) and run:
 npm install -g jgf-dot
 ```
 
-Then you can do the conversion using:
+Then you can do the conversion using either:
 
 ```bash
 cat graph.json | jgfdot > graph.dot
+jgfdot graph.json > graph.dot
 ```
 
 ### `jgfdot`
-Reads a json graph from `STDIN` and outputs the Dot file to `STDOUT`
+Reads a json graph from `STDIN` or `file_name` and outputs the Dot file to `STDOUT`
 
 ## Javascript API
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,19 +1,20 @@
 #! /usr/bin/env node
 
-var read = require("stream-read");
-var toDot = require("../");
+var process = require('process');
 
-read(process.stdin, parse);
+var toDot = require('../');
 
-function parse(err, graph) {
-	if (err) return error(err);
-	write(toDot(JSON.parse(graph)));
-}
+var fileContent = '';
 
-function write(graph) {
-	process.stdout.write(graph);
-}
+process.stdin.setEncoding('utf8');
 
-function error(err) {
-	process.stderr.write(err);
-}
+process.stdin.on('readable', function() {
+  var chunk = process.stdin.read()
+  if (chunk !== null) {
+    fileContent += chunk
+  }
+});
+
+process.stdin.on('end', function() {
+  process.stdout.write(toDot(JSON.parse(fileContent)));
+});

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,19 +2,11 @@
 
 var process = require('process');
 
+var read = require('read-file-stdin');
+
 var toDot = require('../');
 
-var fileContent = '';
-
-process.stdin.setEncoding('utf8');
-
-process.stdin.on('readable', function() {
-  var chunk = process.stdin.read()
-  if (chunk !== null) {
-    fileContent += chunk
-  }
-});
-
-process.stdin.on('end', function() {
-  process.stdout.write(toDot(JSON.parse(fileContent)));
+read(process.argv[2], function (err, buffer) {
+  if (err) throw err;
+  process.stdout.write(toDot(JSON.parse(buffer)));
 });

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
 	"homepage": "https://github.com/jsongraph/jgf-dot#readme",
 	"dependencies": {
 		"graphlib-dot": "^0.6.2",
-		"graphlib-json-graph": "^1.0.0",
-		"stream-read": "^1.1.2"
+		"graphlib-json-graph": "^1.0.0"
 	},
 	"bin": {
 		"jgfdot": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,34 +1,35 @@
 {
-	"name": "jgf-dot",
-	"version": "1.0.1",
-	"description": "Convert a json graph into a dot file for use with Graphviz and other visualizers",
-	"main": "index.js",
-	"scripts": {
-		"test": "cat example/graph.json | node cli.js > example/graph.dot"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/jsongraph/jgf-dot.git"
-	},
-	"keywords": [
-		"json",
-		"graph",
-		"format",
-		"dot",
-		"graphviz",
-		"visualize"
-	],
-	"author": "rangermauve",
-	"license": "ISC",
-	"bugs": {
-		"url": "https://github.com/jsongraph/jgf-dot/issues"
-	},
-	"homepage": "https://github.com/jsongraph/jgf-dot#readme",
-	"dependencies": {
-		"graphlib-dot": "^0.6.2",
-		"graphlib-json-graph": "^1.0.0"
-	},
-	"bin": {
-		"jgfdot": "bin/cli.js"
-	}
+  "name": "jgf-dot",
+  "version": "1.0.1",
+  "description": "Convert a json graph into a dot file for use with Graphviz and other visualizers",
+  "main": "index.js",
+  "scripts": {
+    "test": "cat example/graph.json | node cli.js > example/graph.dot"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jsongraph/jgf-dot.git"
+  },
+  "keywords": [
+    "json",
+    "graph",
+    "format",
+    "dot",
+    "graphviz",
+    "visualize"
+  ],
+  "author": "rangermauve",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/jsongraph/jgf-dot/issues"
+  },
+  "homepage": "https://github.com/jsongraph/jgf-dot#readme",
+  "dependencies": {
+    "graphlib-dot": "^0.6.2",
+    "graphlib-json-graph": "^1.0.0",
+    "read-file-stdin": "^0.2.1"
+  },
+  "bin": {
+    "jgfdot": "bin/cli.js"
+  }
 }


### PR DESCRIPTION
With big input files (> 100 kb), the buffer is truncated, leading to this error:

```
$ jgfdot < graph.json 
undefined:3117

SyntaxError: Unexpected end of input
    at Object.parse (native)
    at parse (/home/cbenz/Dev/vendor/jgf-dot/bin/cli.js:10:19)
    at zalgoSafe (/home/cbenz/Dev/vendor/jgf-dot/node_modules/dezalgo/dezalgo.js:20:10)
    at check (/home/cbenz/Dev/vendor/jgf-dot/node_modules/stream-read/index.js:87:14)
    at ReadStream.onreadable (/home/cbenz/Dev/vendor/jgf-dot/node_modules/stream-read/index.js:47:5)
    at emitNone (events.js:67:13)
    at ReadStream.emit (events.js:166:7)
    at emitReadable_ (_stream_readable.js:411:10)
    at emitReadable (_stream_readable.js:405:7)
    at readableAddChunk (_stream_readable.js:157:11)
```

So I rewrote it using [`read-file-stdin`](https://github.com/ianstormtaylor/read-file-stdin) which is minimalist and accepts reading from a `file_name`. I also updated the README.

I hope it's correct and idiomatic.
